### PR TITLE
allow proxy and custom httpClient

### DIFF
--- a/lib/src/flutter_google_places.dart
+++ b/lib/src/flutter_google_places.dart
@@ -6,6 +6,7 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:google_maps_webservice/places.dart';
+import 'package:http/http.dart';
 import 'package:rxdart/rxdart.dart';
 
 class PlacesAutocompleteWidget extends StatefulWidget {
@@ -31,6 +32,12 @@ class PlacesAutocompleteWidget extends StatefulWidget {
 
   final String proxyBaseUrl;
 
+  /// optional - set 'client' value in google_maps_webservice
+  /// 
+  /// In case of using a proxy url that requires authentication
+  /// or custom configuration
+  final BaseClient httpClient;
+
   PlacesAutocompleteWidget(
       {@required this.apiKey,
       this.mode = Mode.fullscreen,
@@ -46,7 +53,8 @@ class PlacesAutocompleteWidget extends StatefulWidget {
       this.logo,
       this.onError,
       Key key,
-      this.proxyBaseUrl})
+      this.proxyBaseUrl,
+      this.httpClient})
       : super(key: key);
 
   @override
@@ -332,14 +340,11 @@ abstract class PlacesAutocompleteState extends State<PlacesAutocompleteWidget> {
     super.initState();
     _queryTextController = TextEditingController(text: "");
 
-    if (widget.proxyBaseUrl != null) {
       _places = GoogleMapsPlaces(
         apiKey: widget.apiKey,
         baseUrl: widget.proxyBaseUrl,
+        httpClient: widget.httpClient
       );
-    } else {
-      _places = GoogleMapsPlaces(apiKey: widget.apiKey);
-    }
     _searching = false;
 
     _queryTextController.addListener(_onQueryChange);
@@ -431,7 +436,8 @@ class PlacesAutocomplete {
       bool strictbounds,
       Widget logo,
       ValueChanged<PlacesAutocompleteResponse> onError,
-      String proxyBaseUrl}) {
+      String proxyBaseUrl,
+      Client httpClient}) {
     final builder = (BuildContext ctx) => PlacesAutocompleteWidget(
           apiKey: apiKey,
           mode: mode,
@@ -447,6 +453,7 @@ class PlacesAutocomplete {
           logo: logo,
           onError: onError,
           proxyBaseUrl: proxyBaseUrl,
+          httpClient: httpClient
         );
 
     if (mode == Mode.overlay) {

--- a/lib/src/flutter_google_places.dart
+++ b/lib/src/flutter_google_places.dart
@@ -23,22 +23,31 @@ class PlacesAutocompleteWidget extends StatefulWidget {
   final Widget logo;
   final ValueChanged<PlacesAutocompleteResponse> onError;
 
-  PlacesAutocompleteWidget({
-    @required this.apiKey,
-    this.mode = Mode.fullscreen,
-    this.hint = "Search",
-    this.offset,
-    this.location,
-    this.radius,
-    this.language,
-    this.sessionToken,
-    this.types,
-    this.components,
-    this.strictbounds,
-    this.logo,
-    this.onError,
-    Key key,
-  }) : super(key: key);
+  /// optional - sets 'proxy' value in google_maps_webservice
+  ///
+  /// In case of using a proxy the baseUrl can be set.
+  /// The apiKey is not required in case the proxy sets it.
+  /// (Not storing the apiKey in the app is good practice)
+
+  final String proxyBaseUrl;
+
+  PlacesAutocompleteWidget(
+      {@required this.apiKey,
+      this.mode = Mode.fullscreen,
+      this.hint = "Search",
+      this.offset,
+      this.location,
+      this.radius,
+      this.language,
+      this.sessionToken,
+      this.types,
+      this.components,
+      this.strictbounds,
+      this.logo,
+      this.onError,
+      Key key,
+      this.proxyBaseUrl})
+      : super(key: key);
 
   @override
   State<PlacesAutocompleteWidget> createState() {
@@ -323,7 +332,14 @@ abstract class PlacesAutocompleteState extends State<PlacesAutocompleteWidget> {
     super.initState();
     _queryTextController = TextEditingController(text: "");
 
-    _places = GoogleMapsPlaces(apiKey: widget.apiKey);
+    if (widget.proxyBaseUrl != null) {
+      _places = GoogleMapsPlaces(
+        apiKey: widget.apiKey,
+        baseUrl: widget.proxyBaseUrl,
+      );
+    } else {
+      _places = GoogleMapsPlaces(apiKey: widget.apiKey);
+    }
     _searching = false;
 
     _queryTextController.addListener(_onQueryChange);
@@ -414,7 +430,8 @@ class PlacesAutocomplete {
       List<Component> components,
       bool strictbounds,
       Widget logo,
-      ValueChanged<PlacesAutocompleteResponse> onError}) {
+      ValueChanged<PlacesAutocompleteResponse> onError,
+      String proxyBaseUrl}) {
     final builder = (BuildContext ctx) => PlacesAutocompleteWidget(
           apiKey: apiKey,
           mode: mode,
@@ -429,6 +446,7 @@ class PlacesAutocomplete {
           hint: hint,
           logo: logo,
           onError: onError,
+          proxyBaseUrl: proxyBaseUrl,
         );
 
     if (mode == Mode.overlay) {


### PR DESCRIPTION
I like this plugin but I have concerns about the security of my API Key.  

Rather than having the key on the phone where it is vulnerable to theft, I want to proxy calls to my back-end where I can control it.  Setting a proxy and custom http client is possible in the underlying google_webservice.  This pull request simply exposes the properties.

usage is 
`
    Prediction p = await PlacesAutocomplete.show(
        context: context,
        apiKey: null,
        httpClient: ACustomHttpClient(),
        proxyBaseUrl: "http://example.com",
        mode: Mode.overlay,
        language: "en",
        components: [new Component(Component.country, "uk")]);
`
