### PR TITLE
updating http dependency to fix conflict

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   rxdart: ^0.20.0
   google_maps_webservice: ^0.0.10
-  http: ^0.11.3
+  http: 0.12.0+1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   rxdart: ^0.20.0
   google_maps_webservice: ^0.0.10
-  http: 0.12.0+1
+  http: ">=0.11.0 <1.0.0"
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
flutter_google_places currently depends on http ^0.11.3 which is causing conflict with latest flutter_advanced_networkimage, merge this commit to fix issue. 

Thanks.