### PR TITLE
Updates RxDart to 0.21.0

### DIFF
--- a/lib/src/flutter_google_places.dart
+++ b/lib/src/flutter_google_places.dart
@@ -340,7 +340,7 @@ abstract class PlacesAutocompleteState extends State<PlacesAutocompleteWidget> {
   GoogleMapsPlaces _places;
   bool _searching;
 
-  final _queryBehavior = BehaviorSubject<String>(seedValue: '');
+  final _queryBehavior = BehaviorSubject<String>.seeded('');
 
   @override
   void initState() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_google_places
 description: Google places autocomplete widgets for flutter. No wrapper, use https://pub.dartlang.org/packages/google_maps_webservice
-version: 0.2.0
+version: 0.2.2
 author: Hadrien Lejard <hadrien.lejard@gmail.com>
 homepage: https://github.com/lejard-h/flutter_google_places
 
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  rxdart: ^0.20.0
+  rxdart: ^0.21.0
   google_maps_webservice: ^0.0.10
   http: ">=0.11.0 <1.0.0"
 


### PR DESCRIPTION
This is currently causing flutter_google_places to be incompatible with packages that require RxDart 0.21.0.

Addresses #53